### PR TITLE
Stylesheet injector for Dark Mode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,7 +43,7 @@
   "web_accessible_resources": [
     {
       "matches": [ "https://app.dataannotation.tech/*" ],
-      "resources": [ "./styles/dark-mode.css" ]
+      "resources": [ "styles/dark-mode.css" ]
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,10 @@
   "name": "DAT Extension",
   "version": "1.0",
   "description": "Skip tasks and copy response code easier. Automatically sort tasks by pay.",
-  "permissions": ["activeTab","storage"],
+  "permissions": [
+    "activeTab",
+    "storage"
+  ],
   "action": {
     "default_popup": "./html/popup.html",
     "default_icon": {
@@ -14,25 +17,31 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://app.dataannotation.tech/*"],
+      "matches": [ "https://app.dataannotation.tech/*" ],
       "js": [
         "./scripts/darkMode.js",
         "./scripts/stopWatchOverlay.js"
       ]
     },
     {
-      "matches": ["https://app.dataannotation.tech/workers/tasks/*"],
+      "matches": [ "https://app.dataannotation.tech/workers/tasks/*" ],
       "js": [
         "./scripts/skipCommand.js",
         "./scripts/codeCopy.js"
       ]
     },
     {
-      "matches": ["https://app.dataannotation.tech/workers/projects"],
+      "matches": [ "https://app.dataannotation.tech/workers/projects" ],
       "js": [
         "./scripts/descendingFilter.js", 
         "./scripts/colorCodeProjects.js"
       ]
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "matches": [ "https://app.dataannotation.tech/*" ],
+      "resources": [ "./styles/dark-mode.css" ]
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -18,10 +18,12 @@
   "content_scripts": [
     {
       "matches": [ "https://app.dataannotation.tech/*" ],
-      "js": [
-        "./scripts/darkMode.js",
-        "./scripts/stopWatchOverlay.js"
-      ]
+      "js": [ "./scripts/darkMode.js" ],
+      "run_at": "document_start"
+    },
+    {
+      "matches": [ "https://app.dataannotation.tech/*" ],
+      "js": [ "./scripts/stopWatchOverlay.js" ]
     },
     {
       "matches": [ "https://app.dataannotation.tech/workers/tasks/*" ],

--- a/scripts/darkMode.js
+++ b/scripts/darkMode.js
@@ -1,61 +1,109 @@
-const bg = '#070F2B';
-const txt = '#9290C3'
-const acc = '#535C91';
-const scrll = '#1B1A55';
-const nav = '#04091a'
-let isDark = false;
-const style = document.createElement('style');
-style.textContent = `
-    /* Set background color and text color for all elements except pre, span and code inside pre, and textarea */
-    *:not(pre):not(pre span):not(pre code):not(textarea) {
-        background-color: ${bg}!important;
-        color: ${txt} !important;
-    }
-    .navbar.navbar-dark.navbar-inverse.bg-primary.navbar-expand-sm{
-        background-color: ${nav}!important;
-        color: ${txt} !important;
-        }
-    .navbar.navbar-dark.navbar-inverse.bg-primary.navbar-expand-sm > *{
-        background-color: ${nav}!important;
-        color: ${txt} !important;
-        }
-    textarea {
-        background-color:${acc} !important;
-    }
-    ::-webkit-scrollbar {
-    background: ${scrll} !important; /* color of the scrollbar track on hover */
-    }
-    /* Change the color of the scrollbar handle */
-    ::-webkit-scrollbar-thumb {
-        background: ${acc} !important; /* color of the scrollbar handle */
-    }
-        ::-webkit-scrollbar-thumb:hover {
-        background: ${txt} !important; /* color of the scrollbar handle */
-    }
-    
-`;
-
-
-function toggleDarkMode(bool){
-    if(bool && !isDark){
-        // Append the style element to the document's head to apply the styles
-        document.head.appendChild(style);
-        isDark = true;
-    }
-    else{
-        style.parentNode.removeChild(style)
-        isDark = false
-    }
-
-
+/*
+ * Get the style element for dark mode
+ * @returns {HTMLStyleElement} the style element
+ */
+async function getStyleElement() {
+  /* Populate the stylesheet if it hasn't already been done */
+  if (styleElement.innerText === '') {
+    const string = await getStylesheetFromExtension();
+    styleElement.innerText = string;
+  }
+  return styleElement;
 }
-chrome.storage.sync.get(['darkMode'],(r)=>{
-    toggleDarkMode(r.darkMode || false)
-})
 
-chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
-    const isDarkMode = message.darkMode || false;
-    toggleDarkMode(isDarkMode)
+/* 
+ * Loads the stylesheet contents from web accessible resources
+ * @returns {string} the stylesheet string
+ * @throws {Error} Fetch errors that are considered fatal
+ */
+async function getStylesheetFromExtension() {
+  /* This calculates the URL we pass to the fetch function */
+  const url = chrome.runtime.getURL(`styles/dark-mode.css`);
+  let cssString = '';
+  try {
+    const response = await fetch(url);
+    /* Fatal fetch errors */
+    if (!response.ok) {
+      throw new Error(`DAT: Error fetching dark mode stylesheet`);
+    }
+    cssString = await response.text();
+  } catch (error) {
+    /* Recoverable fetch errors */
+    console.error(`DAT: ${error.message}`);
+  }
+  return cssString;
+}
 
+/*
+ * Injects the Dark Mode Stylesheet
+ * @param isToggle {boolean} If the current call is due to a user toggle
+ * @returns {number} The milliseconds spent on delays during initialization
+ * @throws {RangeError} If over 12 seconds are spent delaying injection
+ */
+async function injectStyleElement(isToggle) {
+  if (injectionAttemptMs > 12000) {
+    throw new RangeError('DAT: Failed to inject Dark Mode Styles');
+  }
+  /* document.head can become available prior to the load event */
+  if (document?.head === undefined) {
+    /* 50ms is the widely accepted minimum (excluding 0) that
+       should be used for setTimeout in content scripts */
+    window.setTimeout(()=> injectStyleElement, 50);
+    return injectionAttemptMs += isToggle ? 0 : 50;
+  }
+  /* If it's already injected, we can stop testing for it */
+  if (styleElement.parentElement === document.head) {
+    return injectionAttemptMs;
+  }
+  const element = await getStyleElement();
+  /* In case of a recoverable fetch error */
+  if (styleElement.innerText === '') {
+    window.setTimeout(()=> injectStyleElement, 250);
+    return injectionAttemptMs += isToggle ? 0 : 250;
+  }
+  document.head.append(element);
+  /* Verify that the injection worked after 1 second,
+     if not, we do it again until it does! */
+  window.setTimeout(()=> injectStyleElement, 1000);
+  return injectionAttemptMs += isToggle ? 0 : 1000;
+}
+
+/*
+ * Updates the page to (en/dis)able Dark Mode
+ * @param {boolean} status Whether or not Dark Mode should be enabled
+ * @param {boolean} isToggle Was this call user initiated
+ */
+function setDarkMode(status, isToggle = false) {
+  if (status) {
+    injectStyleElement(isToggle);
+    isDark = true;
+  } else {
+    /* We don't want to attempt removal of elements that aren't there */
+    if (styleElement.parentElement === document.head) {
+      style.parentNode.removeChild(styleElement);
+    }
+    isDark = false;
+  }
+}
+
+/* Runtime */
+/* Style Element to be injected into the head */
+const styleElement = document.createElement('style');
+/* Whether dark mode is currently enabled */
+let isDark = false;
+/* Number of injection attempts by delay time to limit failed retries */
+let injectionAttemptMs = 0;
+
+/* Get option from storage and pass it to the setDarkMode function */
+chrome.storage.sync.get({ darkMode: false }, (result) => {
+  setDarkMode(result.darkMode, true);
 });
 
+/* Listen for messages that toggle dark mode */
+chrome.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
+  /* Verify the message has a property 'darkMode' */
+  if (Object.hasOwnProperty(message, 'darkMode')) {
+  /* If so, pass it to the setDarkMode function */
+    setDarkMode(message.darkMode, true);
+  }
+});

--- a/styles/dark-mode.css
+++ b/styles/dark-mode.css
@@ -1,0 +1,29 @@
+/* Set background color and text color for all elements except pre, span and code inside pre, and textarea */
+*:not(pre):not(pre span):not(pre code):not(textarea) {
+  background-color: #070F2B !important;
+  color: #9290C3 !important;
+}
+
+.navbar.navbar-dark.navbar-inverse.bg-primary.navbar-expand-sm,
+.navbar.navbar-dark.navbar-inverse.bg-primary.navbar-expand-sm > *{
+  background-color: #04091A !important;
+  color: #9290C3 !important;
+}
+	
+textarea {
+  background-color: #535C91 !important;
+}
+
+::-webkit-scrollbar {
+  background: #1B1A55 !important;
+}
+
+/* color of the scrollbar handle */
+::-webkit-scrollbar-thumb {
+  background: #535C91 !important; 
+}
+
+/* Color of the scrollbar handle on hover */
+::-webkit-scrollbar-thumb:hover {
+  background: #9290C3 !important;
+}


### PR DESCRIPTION
## Stylesheet Injector for Dark Mode

Per this comment:
![image](https://github.com/user-attachments/assets/16d4edf7-7e77-42aa-80f2-2ad405c555be)

I've implemented an injection system for the Dark Mode Stylesheet.  I haven't tested this yet, so don't merge it without a good test run.  Makes the following changes:
1. Migrates the CSS out of ```scripts/darkMode.js``` and into ```styles/dark-mode.css```.
2. Adds the above CSS file to the manifest as a Web Accessible Resource.
3. Changes the dark mode content script manifest entry to run at document_start.  So we can get those styles in quickly.
4. Reworks ```scripts/darkMode.js``` to fetch the sheet and inject